### PR TITLE
Fix PiecewiseConstantWarmUpDecay lambda capture

### DIFF
--- a/modules/lr_scheduler.py
+++ b/modules/lr_scheduler.py
@@ -75,7 +75,7 @@ class PiecewiseConstantWarmUpDecay(
                                     values[1:-1]):
                 # Need to bind v here; can do this with lambda v=v: ...
                 pred = (step > low) & (step <= high)
-                pred_fn_pairs.append((pred, lambda: tf.constant(v)))
+                pred_fn_pairs.append((pred, lambda captured=tf.constant(v): captured))
 
             # The default isn't needed here because our conditions are mutually
             # exclusive and exhaustive, but tf.case requires it.

--- a/modules/lr_scheduler.py
+++ b/modules/lr_scheduler.py
@@ -73,7 +73,6 @@ class PiecewiseConstantWarmUpDecay(
 
             for low, high, v in zip(boundaries[:-1], boundaries[1:],
                                     values[1:-1]):
-                # Need to bind v here; can do this with lambda v=v: ...
                 pred = (step > low) & (step <= high)
                 pred_fn_pairs.append((pred, lambda captured=tf.constant(v): captured))
 


### PR DESCRIPTION
The bug wasn't noticed as in the current config `lr_decay_epoch`
is of length 2 and the loop occurs len(`lr_decay_epoch`)-1 times (1 by default), and the bug requires >=3 iterations.

Bug causes same learning rate (one before last) for all schedule steps starting from the second after the warmup.

The lambdas used to reference the same variable v which was updated in each iteration - 
which caused all of them to return the same one (which was assigned on the last iteration of the loop)
Fixed by capturing via the default argument of lambda "hack". 